### PR TITLE
Fix creating a new lobby

### DIFF
--- a/internal/lobbies/repository.go
+++ b/internal/lobbies/repository.go
@@ -111,7 +111,7 @@ func (s *inMemoryLobbyRepository) GetLobbyByHost(host clientID) (*lobby, error) 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	for _, l := range s.lobbies {
-		if l.Host.ClientID == host {
+		if l.Host != nil && l.Host.ClientID == host {
 			return l, nil
 		}
 	}

--- a/internal/lobbies/routes.go
+++ b/internal/lobbies/routes.go
@@ -90,8 +90,8 @@ func postLobbiesHandler(w http.ResponseWriter, r *http.Request) {
 			// Redirect to the lobby
 			w.Header().Add("HX-Redirect", "/lobbies/"+lobby.Pin)
 			w.WriteHeader(http.StatusFound)
+			return
 		}
-		return
 	}
 	// Otherwise, create a new lobby
 


### PR DESCRIPTION
When calling GetLobbyByHost, a lobby with empty host crashed the system as there was a null pointer reference.
Additionally fixed a bug where a client with specified client-id but without being a lobby host, couldn't create a new lobby because of a typo