### PR TITLE
Remove IsHost from user struct

### DIFF
--- a/internal/lobbies/events.go
+++ b/internal/lobbies/events.go
@@ -75,7 +75,6 @@ func handleNewWebsocketConn(l *lobby, conn *websocket.Conn, clientID clientID) (
 	case l.Host == nil:
 		slog.Info("New Host for the Lobby", "Lobby-Pin", l.Pin, "Client-ID", connectedUser.ClientID)
 		l.Host = connectedUser
-		connectedUser.IsHost = true
 
 	// Check if host is trying to reconnect
 	case l.Host.ClientID == connectedUser.ClientID:

--- a/internal/lobbies/user.go
+++ b/internal/lobbies/user.go
@@ -14,7 +14,6 @@ type user struct {
 	Conn                 *websocket.Conn
 	ClientID             clientID
 	Username             string
-	IsHost               bool
 	SubmittedAnswerIdx   int
 	AnswerSubmissionTime time.Time
 	Score                int64

--- a/templates/results.html
+++ b/templates/results.html
@@ -8,7 +8,9 @@
     <h1>Lobby Results View</h1>
     {{ range .Lobby.Leaderboard }}
     <p>{{ .Username }}: {{ .Score }} points</p>
-    {{ end }} {{ if .User.IsHost }}
+    {{ end }}
+    <!---->
+    {{ if eq .Lobby.Host .User }}
     <button name="close-lobby-btn" ws-send>Continue</button>
     {{ end}}
   </body>

--- a/templates/views/answer-view.html
+++ b/templates/views/answer-view.html
@@ -2,7 +2,7 @@
   <h1>Answer view</h1>
   <p>Your new points: {{.User.NewPoints}}</p>
   <p>Your score: {{.User.Score}}</p>
-  {{ if .User.IsHost }}
+  {{ if eq .Lobby.Host .User}}
   <button name="next-question-btn" ws-send class="rounded bg-blue-200 p-1">
     {{ if eq .Lobby.CurrentQuestionIdx (decrement (len .Lobby.Quiz.Questions)) }} Finish Quiz {{ else }} Next Question
     {{ end }}

--- a/templates/views/on-finish-view.html
+++ b/templates/views/on-finish-view.html
@@ -1,5 +1,5 @@
 <div id="view">
-  {{ if .User.IsHost }}
+  {{ if eq .Lobby.Host .User }}
   <script>
     // TODO: Sends Host to the lobby results view
     window.location.href = "/";

--- a/templates/views/question-view.html
+++ b/templates/views/question-view.html
@@ -135,7 +135,7 @@
         </div>
         {{ end }}
         <!-- Skip to answer button -->
-        {{ if .User.IsHost }}
+        {{ if eq .Lobby.Host .User }}
         <button name="skip-to-answer-btn" ws-send class="rounded bg-blue-200 p-1">Skip to Answer</button>
         {{ end }}
       </div>
@@ -151,7 +151,7 @@
           {{ end}}
         </p>
         <!-- Score Counter -->
-        {{ if .User.IsHost }}
+        {{ if eq .Lobby.Host .User }}
         <!-- The host doesn't have a score -->
         {{ else }}
         <p class="text-lg md:text-xl font-semibold text-dark-green">

--- a/templates/views/waiting-room-view.html
+++ b/templates/views/waiting-room-view.html
@@ -25,7 +25,7 @@
   </style>
 
   <!-- View for Host -->
-  {{ if .User.IsHost }}
+  {{ if eq .Lobby.Host .User }}
   <div class="text-center">
     <h0 class="text-3xl font-bold mb-4 text-white">GAME SETTINGS</h0>
     <h1 class="text-xl font-bold mt-4 mb-4 text-dark-green">Your Lobby Pin: {{ .Lobby.Pin }}</h1>


### PR DESCRIPTION
The field is redundant as all templates that have access to User
have access to Lobby as well. One can compare .Lobby.Host with User
Using {{ if eq .Lobby.Host .User }}
